### PR TITLE
added Platform specific padding for the android OS in homeStyles.js s…

### DIFF
--- a/mobile-app/src/Components/HomeTab/Home/homeStyles.js
+++ b/mobile-app/src/Components/HomeTab/Home/homeStyles.js
@@ -62,6 +62,11 @@ export const homeStyles = StyleSheet.create({
     signOutStyle: {
       alignItems: 'flex-end',
       justifyContent: 'flex-end',
-      paddingRight: 15,
+      paddingRight: 40,
+      ...Platform.select({
+        android: {
+          paddingTop: 25, // Add top padding for Android Sign Out Button
+        },
+      }),
     },
   });


### PR DESCRIPTION
…ignOutStyle
<img width="1685" alt="Screenshot 2023-11-28 at 12 06 06 PM" src="https://github.com/trinacorrao/homeset/assets/110434197/f84a635b-1417-4e4d-917d-1c9111d6b42e">


You should be able to adjust the custom padding for android and see if the signout button becomes clickable/ works