### PR TITLE
added android font family that works serif

### DIFF
--- a/mobile-app/src/Components/HomeTab/Home/homeStyles.js
+++ b/mobile-app/src/Components/HomeTab/Home/homeStyles.js
@@ -49,6 +49,11 @@ export const homeStyles = StyleSheet.create({
       fontSize: 52,
       fontWeight: 'bold',
       fontFamily: 'Georgia',
+      ...Platform.select({
+        android: {
+          fontFamily: 'serif', // Android compatible font
+        },
+      }),
       color: '#033596',
       marginTop: 10,
     },
@@ -56,6 +61,11 @@ export const homeStyles = StyleSheet.create({
       fontSize: 20,
       fontWeight: 'bold',
       fontFamily: 'Georgia',
+      ...Platform.select({
+        android: {
+          fontFamily: 'serif', // Android compatible font
+        },
+      }),
       color: '#033596',
       marginTop: 10,
     },


### PR DESCRIPTION
<img width="712" alt="Screenshot 2023-11-29 at 10 14 05 AM" src="https://github.com/trinacorrao/homeset/assets/110434197/7b488ba2-887f-4b35-a798-dacf72b59e6a">


I added Android specific fontFamily, there is a very small library of fonts that work and react native is not good at being responsive when it comes to fonts apparently.